### PR TITLE
[FEAT] グループ一覧画面を作成

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@react-google-maps/api": "^2.20.3",
     "@remix-run/react": "^2.13.1",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@tanstack/react-table": "^8.20.5",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@remix-run/react':
         specifier: ^2.13.1
         version: 2.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@tailwindcss/line-clamp':
+        specifier: ^0.4.4
+        version: 0.4.4(tailwindcss@3.4.14)
       '@tanstack/react-table':
         specifier: ^8.20.5
         version: 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1418,6 +1421,11 @@ packages:
 
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
+  '@tailwindcss/line-clamp@0.4.4':
+    resolution: {integrity: sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==}
+    peerDependencies:
+      tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
 
   '@tanstack/react-table@8.20.5':
     resolution: {integrity: sha512-WEHopKw3znbUZ61s9i0+i9g8drmDo6asTWbrQh8Us63DAk/M0FkmIqERew6P71HI75ksZ2Pxyuf4vvKh9rAkiA==}
@@ -4801,6 +4809,10 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.8.0
 
+  '@tailwindcss/line-clamp@0.4.4(tailwindcss@3.4.14)':
+    dependencies:
+      tailwindcss: 3.4.14
+
   '@tanstack/react-table@8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/table-core': 8.20.5
@@ -5455,7 +5467,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -5468,7 +5480,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5490,7 +5502,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/frontend/src/app/(app)/(calendar)/(sidemenu)/groups/page.tsx
+++ b/frontend/src/app/(app)/(calendar)/(sidemenu)/groups/page.tsx
@@ -14,7 +14,7 @@ function Page() {
         </div>
         <GroupSearch />
       </div>
-      <div className="bg-brand-border-color p-6 rounded-lg flex-grow min-h-0 overflow-auto">
+      <div className="bg-gray-100 p-6 rounded-lg flex-grow min-h-0 overflow-auto">
         <GroupList />
       </div>
     </div>

--- a/frontend/src/app/(app)/(calendar)/(sidemenu)/groups/page.tsx
+++ b/frontend/src/app/(app)/(calendar)/(sidemenu)/groups/page.tsx
@@ -1,7 +1,24 @@
 import React from "react";
+import { ViewTitle } from "~/components/common/ViewTitle";
+import GroupList from "~/features/groupList/GroupList";
+import { GroupSearch } from "~/features/groupList/GroupSearch";
 
 function Page() {
-  return <div>あなたが所属しているグループ</div>;
+
+  return (
+    <div className="p-6 h-[calc(100vh-56px)] flex flex-col">
+      <div className="flex justify-between pb-6">
+        <div>
+          <ViewTitle title="グループ一覧" />
+          <div>表示するグループを選択してください。</div>
+        </div>
+        <GroupSearch />
+      </div>
+      <div className="bg-brand-border-color p-6 rounded-lg flex-grow min-h-0 overflow-auto">
+        <GroupList />
+      </div>
+    </div>
+  );
 }
 
 export default Page;

--- a/frontend/src/features/appLayout/components/GroupSwitcher.tsx
+++ b/frontend/src/features/appLayout/components/GroupSwitcher.tsx
@@ -164,6 +164,7 @@ export function GroupSwitcher({ currentGroupId, groups, onChange }: Props) {
           <MenuItemWithIcon
             icon={<List className="mr-2 h-4 w-4" />}
             title="グループ一覧"
+            url="/groups"
           />
           <DropdownMenuItem
             onSelect={() => setIsCGOpen(true)}

--- a/frontend/src/features/groupList/GroupList.tsx
+++ b/frontend/src/features/groupList/GroupList.tsx
@@ -1,6 +1,5 @@
 "use client";
 import React, { useEffect, useState } from 'react'
-import { Card } from '~/components/ui/card';
 import { LoadingSpinner } from '~/components/ui/spinner';
 import useCurrentAccount from '~/hooks/useCurrentAccount';
 import { DBGroup } from "~/lib/firestore/schemas";
@@ -30,7 +29,7 @@ const GroupList = () => {
           <>
             <GroupNewCreateCard />
             {groups.map((group) => (
-              <GroupListCard {...group} />
+              <GroupListCard key={group.uid} {...group} />
             ))
             }
             {/* flexの限界 */}

--- a/frontend/src/features/groupList/GroupList.tsx
+++ b/frontend/src/features/groupList/GroupList.tsx
@@ -1,0 +1,40 @@
+"use client";
+import React, { useEffect, useState } from 'react'
+import { Card } from '~/components/ui/card';
+import { LoadingSpinner } from '~/components/ui/spinner';
+import useCurrentAccount from '~/hooks/useCurrentAccount';
+import { DBGroup } from "~/lib/firestore/schemas";
+
+const GroupList = () => {
+  const { currentDBAccount, getGroupsByAccount } = useCurrentAccount(true);
+  const [groups, setGroups] = useState<DBGroup[] | null | "loading">("loading");
+
+  useEffect(() => {
+    if (currentDBAccount === "loading" || currentDBAccount === null) return;
+
+    getGroupsByAccount(currentDBAccount).then((groups) => {
+      setGroups(groups);
+    });
+  }, [currentDBAccount, getGroupsByAccount]);
+  console.log(groups)
+
+  return (
+    <div className="flex flex-wrap gap-4">
+      {groups === "loading" ? (
+        <LoadingSpinner />
+      ) : groups === null ? (
+        <Card>
+          グループが見つかりませんでした。
+        </Card>
+      ) : (
+        groups.map((group) => (
+          <Card key={group.uid} className="w-[250px] h-[200px]">
+            {group.name}
+          </Card>
+        ))
+      )}
+    </div>
+  )
+}
+
+export default GroupList

--- a/frontend/src/features/groupList/GroupList.tsx
+++ b/frontend/src/features/groupList/GroupList.tsx
@@ -21,16 +21,14 @@ const GroupList = () => {
 
   return (
     <div className="flex flex-wrap gap-4">
-      <GroupNewCreateCard />
       {groups === "loading" ? (
         <LoadingSpinner />
       ) : groups === null ? (
-        <Card>
-          グループが見つかりませんでした。
-        </Card>
+        <GroupNewCreateCard />
       ) :
         (
           <>
+            <GroupNewCreateCard />
             {groups.map((group) => (
               <GroupListCard {...group} />
             ))

--- a/frontend/src/features/groupList/GroupList.tsx
+++ b/frontend/src/features/groupList/GroupList.tsx
@@ -4,13 +4,12 @@ import { Card } from '~/components/ui/card';
 import { LoadingSpinner } from '~/components/ui/spinner';
 import useCurrentAccount from '~/hooks/useCurrentAccount';
 import { DBGroup } from "~/lib/firestore/schemas";
-import Image from "next/image";
+import { GroupListCard } from "./GroupListCard";
+import { GroupNewCreateCard } from './GroupNewCreateCard';
 
 const GroupList = () => {
   const { currentDBAccount, getGroupsByAccount } = useCurrentAccount(true);
   const [groups, setGroups] = useState<DBGroup[] | null | "loading">("loading");
-  const DEFAULT_ICON_URL =
-    "https://firebasestorage.googleapis.com/v0/b/jourmie-181d8.appspot.com/o/group_icons%2FdefaultIcon.png?alt=media&token=ced5dd5a-f87f-4652-9643-76a8579f1249";
 
   useEffect(() => {
     if (currentDBAccount === "loading" || currentDBAccount === null) return;
@@ -19,10 +18,10 @@ const GroupList = () => {
       setGroups(groups);
     });
   }, [currentDBAccount, getGroupsByAccount]);
-  console.log(groups)
 
   return (
     <div className="flex flex-wrap gap-4">
+      <GroupNewCreateCard />
       {groups === "loading" ? (
         <LoadingSpinner />
       ) : groups === null ? (
@@ -33,23 +32,7 @@ const GroupList = () => {
         (
           <>
             {groups.map((group) => (
-              <Card key={group.uid} className="flex-1 min-w-[250px] h-[200px] p-6 shadow">
-                <div className='flex mb-2'>
-                  <Image
-                    src={group.icon_url || DEFAULT_ICON_URL}
-                    alt={group.name || "group icon"}
-                    width={32}
-                    height={32}
-                    className="flex mr-2 rounded-full"
-                  />
-                  <h1 className='text-xl font-bold'>
-                    {group.name}
-                  </h1>
-                </div>
-                <div className=' line-clamp-3'>
-                  {group.description}
-                </div>
-              </Card>
+              <GroupListCard {...group} />
             ))
             }
             {/* flexの限界 */}

--- a/frontend/src/features/groupList/GroupList.tsx
+++ b/frontend/src/features/groupList/GroupList.tsx
@@ -4,10 +4,13 @@ import { Card } from '~/components/ui/card';
 import { LoadingSpinner } from '~/components/ui/spinner';
 import useCurrentAccount from '~/hooks/useCurrentAccount';
 import { DBGroup } from "~/lib/firestore/schemas";
+import Image from "next/image";
 
 const GroupList = () => {
   const { currentDBAccount, getGroupsByAccount } = useCurrentAccount(true);
   const [groups, setGroups] = useState<DBGroup[] | null | "loading">("loading");
+  const DEFAULT_ICON_URL =
+    "https://firebasestorage.googleapis.com/v0/b/jourmie-181d8.appspot.com/o/group_icons%2FdefaultIcon.png?alt=media&token=ced5dd5a-f87f-4652-9643-76a8579f1249";
 
   useEffect(() => {
     if (currentDBAccount === "loading" || currentDBAccount === null) return;
@@ -26,14 +29,40 @@ const GroupList = () => {
         <Card>
           グループが見つかりませんでした。
         </Card>
-      ) : (
-        groups.map((group) => (
-          <Card key={group.uid} className="w-[250px] h-[200px]">
-            {group.name}
-          </Card>
-        ))
-      )}
-    </div>
+      ) :
+        (
+          <>
+            {groups.map((group) => (
+              <Card key={group.uid} className="flex-1 min-w-[250px] h-[200px] p-6 shadow">
+                <div className='flex mb-2'>
+                  <Image
+                    src={group.icon_url || DEFAULT_ICON_URL}
+                    alt={group.name || "group icon"}
+                    width={32}
+                    height={32}
+                    className="flex mr-2 rounded-full"
+                  />
+                  <h1 className='text-xl font-bold'>
+                    {group.name}
+                  </h1>
+                </div>
+                <div className=' line-clamp-3'>
+                  {group.description}
+                </div>
+              </Card>
+            ))
+            }
+            {/* flexの限界 */}
+            <div className='flex-1 min-w-[250px] px-6'>
+            </div>
+            <div className='flex-1 min-w-[250px] px-6'>
+            </div>
+            <div className='flex-1 min-w-[250px] px-6'>
+            </div>
+          </>
+        )
+      }
+    </div >
   )
 }
 

--- a/frontend/src/features/groupList/GroupListCard.tsx
+++ b/frontend/src/features/groupList/GroupListCard.tsx
@@ -26,7 +26,7 @@ const GroupListCard = (prop: DBGroup) => {
             height={32}
             className="mr-2 rounded-full w-8 h-8 object-cover"
           />
-          <h1 className='text-xl font-bold'>
+          <h1 className='text-xl font-semibold'>
             {prop.name}
           </h1>
         </div>

--- a/frontend/src/features/groupList/GroupListCard.tsx
+++ b/frontend/src/features/groupList/GroupListCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Card } from '~/components/ui/card'
 import Image from "next/image";
+import { Button } from '~/components/ui/button';
 import { DBGroup } from "~/lib/firestore/schemas";
 
 const GroupListCard = (prop: DBGroup) => {
@@ -8,23 +9,32 @@ const GroupListCard = (prop: DBGroup) => {
     "https://firebasestorage.googleapis.com/v0/b/jourmie-181d8.appspot.com/o/group_icons%2FdefaultIcon.png?alt=media&token=ced5dd5a-f87f-4652-9643-76a8579f1249";
 
   return (
-    <Card key={prop.uid} className="flex-1 min-w-[250px] h-[200px] p-6 shadow">
-      <div className='flex mb-2'>
-        <Image
-          src={prop.icon_url || DEFAULT_ICON_URL}
-          alt={prop.name || "prop icon"}
-          width={32}
-          height={32}
-          className="flex mr-2 rounded-full"
-        />
-        <h1 className='text-xl font-bold'>
-          {prop.name}
-        </h1>
-      </div>
-      <div className=' line-clamp-3'>
-        {prop.description}
-      </div>
-    </Card>
+    <Button
+      variant='ghost'
+      className="flex-1 min-w-[250px] min-h-[156px] shadow whitespace-normal break-words"
+      onClick={() => {
+        console.log('clicked');
+      }}
+      asChild
+    >
+      <Card key={prop.uid} className="w-hull h-full p-6 flex flex-wrap content-around">
+        <div className='flex mb-2 w-full'>
+          <Image
+            src={prop.icon_url || DEFAULT_ICON_URL}
+            alt={prop.name || "prop icon"}
+            width={32}
+            height={32}
+            className="mr-2 rounded-full w-8 h-8 object-cover"
+          />
+          <h1 className='text-xl font-bold'>
+            {prop.name}
+          </h1>
+        </div>
+        <div className="text-xs w-full line-clamp-3 overflow-hidden min-h-[3.4rem] leading-normal">
+          {prop.description}
+        </div>
+      </Card>
+    </Button>
   )
 }
 

--- a/frontend/src/features/groupList/GroupListCard.tsx
+++ b/frontend/src/features/groupList/GroupListCard.tsx
@@ -3,8 +3,10 @@ import { Card } from '~/components/ui/card'
 import Image from "next/image";
 import { Button } from '~/components/ui/button';
 import { DBGroup } from "~/lib/firestore/schemas";
+import { useRouter } from 'next/navigation';
 
 const GroupListCard = (prop: DBGroup) => {
+  const router = useRouter();
   const DEFAULT_ICON_URL =
     "https://firebasestorage.googleapis.com/v0/b/jourmie-181d8.appspot.com/o/group_icons%2FdefaultIcon.png?alt=media&token=ced5dd5a-f87f-4652-9643-76a8579f1249";
 
@@ -13,7 +15,7 @@ const GroupListCard = (prop: DBGroup) => {
       variant='ghost'
       className="flex-1 min-w-[250px] min-h-[156px] shadow whitespace-normal break-words"
       onClick={() => {
-        console.log('clicked');
+        router.push(`/g/${prop.uid}`);
       }}
       asChild
     >

--- a/frontend/src/features/groupList/GroupListCard.tsx
+++ b/frontend/src/features/groupList/GroupListCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Card } from '~/components/ui/card'
+import Image from "next/image";
+import { DBGroup } from "~/lib/firestore/schemas";
+
+const GroupListCard = (prop: DBGroup) => {
+  const DEFAULT_ICON_URL =
+    "https://firebasestorage.googleapis.com/v0/b/jourmie-181d8.appspot.com/o/group_icons%2FdefaultIcon.png?alt=media&token=ced5dd5a-f87f-4652-9643-76a8579f1249";
+
+  return (
+    <Card key={prop.uid} className="flex-1 min-w-[250px] h-[200px] p-6 shadow">
+      <div className='flex mb-2'>
+        <Image
+          src={prop.icon_url || DEFAULT_ICON_URL}
+          alt={prop.name || "prop icon"}
+          width={32}
+          height={32}
+          className="flex mr-2 rounded-full"
+        />
+        <h1 className='text-xl font-bold'>
+          {prop.name}
+        </h1>
+      </div>
+      <div className=' line-clamp-3'>
+        {prop.description}
+      </div>
+    </Card>
+  )
+}
+
+export { GroupListCard };

--- a/frontend/src/features/groupList/GroupNewCreateCard.tsx
+++ b/frontend/src/features/groupList/GroupNewCreateCard.tsx
@@ -15,13 +15,16 @@ const GroupNewCreateCard = () => {
   }
   return (
     <>
-      <Card className="flex-1 min-w-[250px] h-[200px] p-6 shadow">
-        <Button 
-          onClick={() => setIsCGOpen(true)}>
-          <CirclePlus size={20} />
-          <span>新しいグループを作成</span>
-        </Button>
-      </Card>
+      <Button
+        variant="ghost"
+        className="flex-1 min-w-[250px] min-h-[156px] shadow"
+        onClick={() => setIsCGOpen(true)}
+        asChild
+      >
+        <Card className="w-hull h-full p-6 ">
+          新しいグループを作成
+        </Card>
+      </Button>
       <CreateGroupDialog
         isDialogOpen={isCGOpen}
         setIsDialogOpen={setIsCGOpen}

--- a/frontend/src/features/groupList/GroupNewCreateCard.tsx
+++ b/frontend/src/features/groupList/GroupNewCreateCard.tsx
@@ -17,12 +17,15 @@ const GroupNewCreateCard = () => {
     <>
       <Button
         variant="ghost"
-        className="flex-1 min-w-[250px] min-h-[156px] shadow"
+        className="flex-1 min-w-[250px] min-h-[156px] shadow [&_svg]:w-12 [&_svg]:h-12"
         onClick={() => setIsCGOpen(true)}
         asChild
       >
-        <Card className="w-hull h-full p-6 ">
-          新しいグループを作成
+        <Card className="w-hull h-full p-6 text-xl font-semibold flex flex-col">
+          <CirclePlus/>
+          <div>
+            グループを新規作成
+          </div>
         </Card>
       </Button>
       <CreateGroupDialog

--- a/frontend/src/features/groupList/GroupNewCreateCard.tsx
+++ b/frontend/src/features/groupList/GroupNewCreateCard.tsx
@@ -6,9 +6,10 @@ import CreateGroupDialog from "~/features/groupCreation/CreateGroupDialog";
 import useGroupRouter from "~/hooks/useGroupRouter";
 
 const GroupNewCreateCard = () => {
-  const [openGroupSwitcher, setOpenGroupSwitcher] = useState(false);
+  // 使用しない変数は _ で表記するか、空白で対応する。削除すると呼び出し可能じゃないって怒られる
+  const [, setOpenGroupSwitcher] = useState(false);
   const [isCGOpen, setIsCGOpen] = useState(false);
-  const { groupId, pushToChangeGroup } = useGroupRouter();
+  const { pushToChangeGroup } = useGroupRouter();
   const onChange = (groupId: string) => {
     setOpenGroupSwitcher(false);
     pushToChangeGroup(groupId);

--- a/frontend/src/features/groupList/GroupNewCreateCard.tsx
+++ b/frontend/src/features/groupList/GroupNewCreateCard.tsx
@@ -1,0 +1,34 @@
+import { CirclePlus } from 'lucide-react';
+import React, { useState } from 'react'
+import { Button } from '~/components/ui/button';
+import { Card } from '~/components/ui/card';
+import CreateGroupDialog from "~/features/groupCreation/CreateGroupDialog";
+import useGroupRouter from "~/hooks/useGroupRouter";
+
+const GroupNewCreateCard = () => {
+  const [openGroupSwitcher, setOpenGroupSwitcher] = useState(false);
+  const [isCGOpen, setIsCGOpen] = useState(false);
+  const { groupId, pushToChangeGroup } = useGroupRouter();
+  const onChange = (groupId: string) => {
+    setOpenGroupSwitcher(false);
+    pushToChangeGroup(groupId);
+  }
+  return (
+    <>
+      <Card className="flex-1 min-w-[250px] h-[200px] p-6 shadow">
+        <Button 
+          onClick={() => setIsCGOpen(true)}>
+          <CirclePlus size={20} />
+          <span>新しいグループを作成</span>
+        </Button>
+      </Card>
+      <CreateGroupDialog
+        isDialogOpen={isCGOpen}
+        setIsDialogOpen={setIsCGOpen}
+        switchGroupHandler={onChange}
+      />
+    </>
+  )
+}
+
+export { GroupNewCreateCard };

--- a/frontend/src/features/groupList/GroupNewCreateCard.tsx
+++ b/frontend/src/features/groupList/GroupNewCreateCard.tsx
@@ -6,12 +6,9 @@ import CreateGroupDialog from "~/features/groupCreation/CreateGroupDialog";
 import useGroupRouter from "~/hooks/useGroupRouter";
 
 const GroupNewCreateCard = () => {
-  // 使用しない変数は _ で表記するか、空白で対応する。削除すると呼び出し可能じゃないって怒られる
-  const [, setOpenGroupSwitcher] = useState(false);
   const [isCGOpen, setIsCGOpen] = useState(false);
   const { pushToChangeGroup } = useGroupRouter();
   const onChange = (groupId: string) => {
-    setOpenGroupSwitcher(false);
     pushToChangeGroup(groupId);
   }
   return (
@@ -23,7 +20,7 @@ const GroupNewCreateCard = () => {
         asChild
       >
         <Card className="w-hull h-full p-6 text-xl font-semibold flex flex-col">
-          <CirclePlus/>
+          <CirclePlus />
           <div>
             グループを新規作成
           </div>

--- a/frontend/src/features/groupList/GroupSearch.tsx
+++ b/frontend/src/features/groupList/GroupSearch.tsx
@@ -1,0 +1,17 @@
+import { Search } from 'lucide-react'
+import React from 'react'
+import { Button } from '~/components/ui/button'
+
+const GroupSearch = () => {
+  return (
+    (
+      <div className="flex items-end">
+        <Button>
+          <Search />
+        </Button>
+      </div>
+    )
+  )
+}
+
+export { GroupSearch };

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,6 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
+import lineClamp from "@tailwindcss/line-clamp";
 
 const config: Config = {
   darkMode: ["class"],
@@ -62,6 +64,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate, lineClamp],
 };
 export default config;


### PR DESCRIPTION
## グループ一覧ボタンを押したら表示される部分を作成しました。
<img width="212" alt="image" src="https://github.com/user-attachments/assets/359377e9-e674-446a-9f0a-0d21a298b58a" />

### やったこと

- レスポンシブになるようになっているはずです。
- グループ新規作成カードと既存のグループカードはそれぞれ新規作成ダイアログを出す遷移と既存のグループページに飛ぶようになってます。

### やってないこと

- 検索ボタンはfigamにあったらか追加したけど特にまだ機能はない()

### 質問
- カードに適当にボタン要素当てたけど遷移方法それじゃない方がいいとかあったら教えて欲しい
- `router.push`以外の遷移方法でいいのあったら教えて

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/6cffc0dd-b8fe-4748-b268-013ddeefc6ef" />
